### PR TITLE
Switch to rustls for reqwest

### DIFF
--- a/gcloud-sdk/Cargo.toml
+++ b/gcloud-sdk/Cargo.toml
@@ -449,7 +449,7 @@ tokio= { version =  "1.22" }
 tracing = "0.1"
 secret-vault-value = { version="0.3", features=["proto", "serde"] }
 once_cell = "1.16"
-reqwest = { version="0.11", features=["hyper-rustls", "multipart", "json", "gzip", "stream"]  }
+reqwest = { version="0.11", features=["rustls-tls", "multipart", "json", "gzip", "stream"], default-features = false  }
 bytes = { version = "1.2" }
 
 [dev-dependencies]


### PR DESCRIPTION
The dependency on `reqwest` currently causes this package to indirectly depend on `openssl` on Linux due to its [native-tls](https://crates.io/crates/native-tls) feature being enabled by default. I noticed this package already uses `rustls` in other areas, which is much more portable. Would it make sense to switch entirely?