### PR TITLE
fix GuestOsFeature

### DIFF
--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/models/guest_os_feature.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/models/guest_os_feature.rs
@@ -49,6 +49,12 @@ pub enum Type {
     VirtioScsiMultiqueue,
     #[serde(rename = "WINDOWS")]
     Windows,
+    #[serde(rename = "SUSPEND_RESUME_COMPATIBLE")]
+    SuspendResumeCompatible,
+    #[serde(rename = "TDX_CAPABLE")]
+    TdxCapable,
+    #[serde(rename = "IDPF")]
+    Idpf,
 }
 
 impl Default for Type {


### PR DESCRIPTION
Guest Os Features has various values, but IDPF, TDX_CAPABLE, and SUSPEND_RESUME_COMPATIBLE were missing.
