### PR TITLE
Bug Fix: update gce_metadata_client.rs

### DIFF
--- a/gcloud-sdk/src/token_source/gce/gce_metadata_client.rs
+++ b/gcloud-sdk/src/token_source/gce/gce_metadata_client.rs
@@ -135,7 +135,7 @@ impl GceMetadataClient {
         match self.availability {
             GceMetadataClientAvailability::Available(ref client, ref metadata_server_host) => {
                 let url = format!(
-                    "http://{}/{}",
+                    "http://{}{}",
                     metadata_server_host,
                     path_and_query.as_str()
                 );


### PR DESCRIPTION
String interpolation added a redundant slash after host, which causes gcloud sdk 0.25.0 to generate `http://metadata.google.internal//computeMetadata/v1/....` instead of `http://metadata.google.internal/computeMetadata/v1/....`, which results in 404 error.
This bug also affects firestore-rs 0.43.