### PR TITLE
fix: Add empty JSON body to compute_instances_detach_disk

### DIFF
--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/instances_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/instances_api.rs
@@ -3174,6 +3174,9 @@ pub async fn compute_instances_detach_disk(
         local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
     };
 
+    // Add an empty JSON object as body to ensure Content-Length is set
+    local_var_req_builder = local_var_req_builder.json(&serde_json::json!({}));
+
     let local_var_req = local_var_req_builder.build()?;
     let local_var_resp = local_var_client.execute(local_var_req).await?;
 


### PR DESCRIPTION
This PR adds an empty JSON body to the compute_instances_detach_disk API request to ensure that the Content-Length header is properly set. This is required for the API call to function correctly.

Changes:
- Added empty JSON object as request body in compute_instances_detach_disk function
- Ensures Content-Length header is set in the request