### PR TITLE
fix: Surface token refresh failures as a distinct authentication error

### DIFF
--- a/gcloud-sdk/Cargo.toml
+++ b/gcloud-sdk/Cargo.toml
@@ -458,6 +458,9 @@ aws-credential-types = { version = "1.2.1", optional = true }
 percent-encoding = { version = "2.3", optional = true }
 
 
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util"] }
+
 [package.metadata.release]
 tag-prefix=""
 

--- a/gcloud-sdk/src/error.rs
+++ b/gcloud-sdk/src/error.rs
@@ -7,6 +7,9 @@ pub enum ErrorKind {
     Http(reqwest::Error),
     /// Http status code that is not 2xx when getting token.
     HttpStatus(reqwest::StatusCode),
+    /// Authentication failed while obtaining or refreshing a token.
+    /// Distinguishes auth failures from errors of the API call itself.
+    Auth(AuthErrorDetails),
     /// GCE metadata service error.
     Metadata(String),
     TonicMetadata(tonic::metadata::errors::InvalidMetadataValue),
@@ -27,6 +30,56 @@ pub enum ErrorKind {
     ExternalCredsSourceError(String),
     #[doc(hidden)]
     __Nonexhaustive,
+}
+
+/// Details of an authentication failure (see [`ErrorKind::Auth`]).
+#[derive(Debug)]
+pub struct AuthErrorDetails {
+    /// HTTP status returned by the authentication endpoint, if any.
+    pub status: Option<reqwest::StatusCode>,
+    /// OAuth error code from the response body (e.g. `invalid_grant`), if present.
+    pub oauth_error: Option<String>,
+    /// Human readable details: the OAuth `error_description` or the raw response body.
+    pub details: Option<String>,
+}
+
+impl AuthErrorDetails {
+    /// A remediation hint for well-known OAuth error codes, if one is available.
+    pub fn hint(&self) -> Option<&'static str> {
+        match self.oauth_error.as_deref() {
+            Some("invalid_grant") => Some(
+                "the credentials are likely expired or revoked; re-authenticate (e.g. `gcloud auth application-default login`) or provide a new service account key",
+            ),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for AuthErrorDetails {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut separate = false;
+        if let Some(ref status) = self.status {
+            write!(f, "HTTP {}", status)?;
+            separate = true;
+        }
+        if let Some(ref e) = self.oauth_error {
+            if separate {
+                write!(f, ", ")?;
+            }
+            write!(f, "oauth error: {}", e)?;
+            separate = true;
+        }
+        if let Some(ref d) = self.details {
+            if separate {
+                write!(f, " ")?;
+            }
+            write!(f, "({})", d)?;
+        }
+        if let Some(hint) = self.hint() {
+            write!(f, ". Hint: {}", hint)?;
+        }
+        Ok(())
+    }
 }
 
 /// Represents errors that can occur during getting token.
@@ -51,6 +104,7 @@ impl fmt::Display for Error {
         match *self.0 {
             Http(ref e) => write!(f, "http error: {}", e),
             HttpStatus(ref s) => write!(f, "http status error: {}", s),
+            Auth(ref details) => write!(f, "authentication error: {}", details),
             Metadata(ref e) => write!(f, "gce metadata service error: {}", e),
             Jwt(ref e) => write!(f, "jwt error: {}", e),
             TokenSource => write!(f, "token source error: not found token source"),

--- a/gcloud-sdk/src/token_source/credentials.rs
+++ b/gcloud-sdk/src/token_source/credentials.rs
@@ -197,6 +197,39 @@ fn httpc_post(url: &str) -> reqwest::RequestBuilder {
         .header(reqwest::header::USER_AGENT, crate::GCLOUD_SDK_USER_AGENT)
 }
 
+// https://www.rfc-editor.org/rfc/rfc6749#section-5.2
+#[derive(Debug, serde::Deserialize)]
+struct OAuthErrorResponse {
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+const OAUTH_ERROR_BODY_MAX_LEN: usize = 512;
+
+async fn auth_error_from_response(resp: reqwest::Response) -> crate::error::Error {
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    let (oauth_error, details) = match serde_json::from_str::<OAuthErrorResponse>(&body) {
+        Ok(oauth_error) => (oauth_error.error, oauth_error.error_description),
+        Err(_) if !body.trim().is_empty() => {
+            let mut body = body;
+            let mut end = OAUTH_ERROR_BODY_MAX_LEN.min(body.len());
+            while !body.is_char_boundary(end) {
+                end -= 1;
+            }
+            body.truncate(end);
+            (None, Some(body))
+        }
+        Err(_) => (None, None),
+    };
+    crate::error::ErrorKind::Auth(crate::error::AuthErrorDetails {
+        status: Some(status),
+        oauth_error,
+        details,
+    })
+    .into()
+}
+
 #[derive(Debug, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct IamCredentialsGenerateAccessToken {
@@ -276,7 +309,7 @@ mod jwt {
             let resp = resp.json::<TokenResponse>().await?;
             Token::try_from(resp)
         } else {
-            Err(crate::error::ErrorKind::HttpStatus(resp.status()).into())
+            Err(super::auth_error_from_response(resp).await)
         }
     }
 }
@@ -319,7 +352,7 @@ mod oauth2 {
             let resp = resp.json::<TokenResponse>().await?;
             Token::try_from(resp)
         } else {
-            Err(crate::error::ErrorKind::HttpStatus(resp.status()).into())
+            Err(super::auth_error_from_response(resp).await)
         }
     }
 }
@@ -425,6 +458,92 @@ mod external_account {
                 &external_account.token_url, status, err_body
             );
             Err(crate::error::ErrorKind::ExternalCredsSourceError(err_text).into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Spawns a local one-shot HTTP server that answers any request with the
+    // given status line and JSON body, and returns its base URL.
+    async fn one_shot_http_server(status_line: &'static str, body: &'static str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 8192];
+            let _ = socket.read(&mut buf).await;
+            let resp = format!(
+                "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                status_line,
+                body.len(),
+                body
+            );
+            socket.write_all(resp.as_bytes()).await.unwrap();
+        });
+        format!("http://{}", addr)
+    }
+
+    fn test_user() -> User {
+        User {
+            client_secret: "test-secret".into(),
+            client_id: "test-client-id".to_string(),
+            refresh_token: "test-refresh-token".into(),
+            quota_project_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_user_token_refresh_invalid_grant() {
+        let url = one_shot_http_server(
+            "400 Bad Request",
+            r#"{"error":"invalid_grant","error_description":"Token has been expired or revoked."}"#,
+        )
+        .await;
+
+        let err = oauth2::fetch_token(&url, &test_user()).await.unwrap_err();
+
+        match err.kind() {
+            crate::error::ErrorKind::Auth(details) => {
+                assert_eq!(details.status, Some(reqwest::StatusCode::BAD_REQUEST));
+                assert_eq!(details.oauth_error.as_deref(), Some("invalid_grant"));
+                assert_eq!(
+                    details.details.as_deref(),
+                    Some("Token has been expired or revoked.")
+                );
+            }
+            other => panic!("expected Auth error, got: {:?}", other),
+        }
+
+        let msg = err.to_string();
+        assert!(msg.contains("authentication error"), "message: {}", msg);
+        assert!(msg.contains("invalid_grant"), "message: {}", msg);
+        assert!(
+            msg.contains("gcloud auth application-default login"),
+            "message: {}",
+            msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_user_token_refresh_non_json_body() {
+        let url = one_shot_http_server("503 Service Unavailable", "upstream unavailable").await;
+
+        let err = oauth2::fetch_token(&url, &test_user()).await.unwrap_err();
+
+        match err.kind() {
+            crate::error::ErrorKind::Auth(details) => {
+                assert_eq!(
+                    details.status,
+                    Some(reqwest::StatusCode::SERVICE_UNAVAILABLE)
+                );
+                assert_eq!(details.oauth_error, None);
+                assert_eq!(details.details.as_deref(), Some("upstream unavailable"));
+            }
+            other => panic!("expected Auth error, got: {:?}", other),
         }
     }
 }


### PR DESCRIPTION
## Problem

When a token refresh/exchange fails — most commonly with expired or revoked local `gcloud auth application-default login` credentials — the error surfaced into the API call was a bare:

```
http status error: 400 Bad Request
```

This is indistinguishable from a malformed API request, even though the OAuth endpoint's response body contains exactly the information needed to diagnose it (`{"error": "invalid_grant", "error_description": "Token has been expired or revoked."}`). That body was discarded.

## Change

- New `ErrorKind::Auth(AuthErrorDetails)` variant that distinguishes authentication failures from errors of the API call itself. `AuthErrorDetails` carries the HTTP status, the OAuth `error` code, and the `error_description` (or a truncated raw body when the response isn't standard OAuth JSON, per RFC 6749 §5.2).
- `AuthErrorDetails::hint()` returns a remediation hint for well-known codes; for `invalid_grant` it suggests re-authenticating via `gcloud auth application-default login` or providing a new service account key.
- Applied to both the service account JWT flow and the user refresh-token flow in `credentials.rs`. The generic shape allows extending it later to the metadata server, external account, and impersonation paths.
- The existing `HttpStatus` variant is kept untouched for compatibility.

The same failure now reads:

```
authentication error: HTTP 400 Bad Request, oauth error: invalid_grant (Token has been expired or revoked.). Hint: the credentials are likely expired or revoked; re-authenticate (e.g. `gcloud auth application-default login`) or provide a new service account key
```

## Testing

Added tests for the user refresh-token flow against a local one-shot HTTP server (new `tokio` dev-dependency for `net`/`io-util`): one for the standard `invalid_grant` OAuth error JSON (asserting the error kind fields and the hint in the message) and one for a non-JSON error body fallback. All existing tests pass; `cargo clippy` reports no new warnings.