### PR TITLE
fix: Do not URL-encode slashes in resource name path parameters

### DIFF
--- a/gcloud-protos-generator/openapi/generate-all.sh
+++ b/gcloud-protos-generator/openapi/generate-all.sh
@@ -54,6 +54,11 @@ do
     sed -i "s/\#\[derive(Clone, Debug, PartialEq, Serialize, Deserialize)\]/\#\[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)\]/g" "$TEMP_OUTPUT"/"$API_NAME"/src/apis/*.rs
     sed -i "s/\#\[derive(Clone, Debug, PartialEq, Serialize, Deserialize)\]/\#\[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)\]/g" "$TEMP_OUTPUT"/"$API_NAME"/src/models/*.rs
 
+    # Full AIP resource names (parent/name/resource) contain '/' that must remain path separators
+    # and not be encoded as %2F (https://github.com/abdolence/gcloud-sdk-rs/issues/251)
+    sed -i "s/urlencode(parent)/urlencode_path(parent)/g; s/urlencode(name)/urlencode_path(name)/g; s/urlencode(resource)/urlencode_path(resource)/g" "$TEMP_OUTPUT"/"$API_NAME"/src/apis/*.rs
+    cat "$TEMPLATES_DIR/urlencode-path.rs" >> "$TEMP_OUTPUT/$API_NAME/src/apis/mod.rs"
+
     rm -fr "${GLOBAL_OUTPUT_DIR:?}/${API_NAME:?}"
     mkdir -p "$GLOBAL_OUTPUT_DIR/$API_NAME"
 

--- a/gcloud-protos-generator/openapi/templates/urlencode-path.rs
+++ b/gcloud-protos-generator/openapi/templates/urlencode-path.rs
@@ -1,0 +1,10 @@
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/bigquery_v2/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/bigquery_v2/apis/mod.rs
@@ -103,3 +103,13 @@ pub mod tabledata_api;
 pub mod tables_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/bigquery_v2/apis/tables_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/bigquery_v2/apis/tables_api.rs
@@ -512,7 +512,7 @@ pub async fn bigquery_tables_get_iam_policy(
     let local_var_uri_str = format!(
         "{}/{resource}:getIamPolicy",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::bigquery_v2::apis::urlencode(resource)
+        resource = crate::google_rest_apis::bigquery_v2::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -877,7 +877,7 @@ pub async fn bigquery_tables_set_iam_policy(
     let local_var_uri_str = format!(
         "{}/{resource}:setIamPolicy",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::bigquery_v2::apis::urlencode(resource)
+        resource = crate::google_rest_apis::bigquery_v2::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -966,7 +966,7 @@ pub async fn bigquery_tables_test_iam_permissions(
     let local_var_uri_str = format!(
         "{}/{resource}:testIamPermissions",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::bigquery_v2::apis::urlencode(resource)
+        resource = crate::google_rest_apis::bigquery_v2::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/cloudresourcemanager_v3/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/cloudresourcemanager_v3/apis/mod.rs
@@ -103,3 +103,13 @@ pub mod tag_keys_api;
 pub mod tag_values_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/cloudresourcemanager_v3/apis/projects_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/cloudresourcemanager_v3/apis/projects_api.rs
@@ -452,7 +452,7 @@ pub async fn cloudresourcemanager_projects_move(
     let local_var_uri_str = format!(
         "{}/v3/{name}:move",
         local_var_configuration.base_path,
-        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(name)
+        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(name)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -675,7 +675,7 @@ pub async fn cloudresourcemanager_projects_undelete(
     let local_var_uri_str = format!(
         "{}/v3/{name}:undelete",
         local_var_configuration.base_path,
-        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(name)
+        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(name)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/cloudresourcemanager_v3/apis/tag_values_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/cloudresourcemanager_v3/apis/tag_values_api.rs
@@ -565,7 +565,7 @@ pub async fn cloudresourcemanager_tag_values_get(
     let local_var_uri_str = format!(
         "{}/v3/{name}",
         local_var_configuration.base_path,
-        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(name)
+        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(name)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -670,7 +670,7 @@ pub async fn cloudresourcemanager_tag_values_get_iam_policy(
     let local_var_uri_str = format!(
         "{}/v3/{resource}:getIamPolicy",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(resource)
+        resource = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1000,7 +1000,7 @@ pub async fn cloudresourcemanager_tag_values_patch(
     let local_var_uri_str = format!(
         "{}/v3/{name}",
         local_var_configuration.base_path,
-        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(name)
+        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(name)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::PATCH, local_var_uri_str.as_str());
@@ -1114,7 +1114,7 @@ pub async fn cloudresourcemanager_tag_values_set_iam_policy(
     let local_var_uri_str = format!(
         "{}/v3/{resource}:setIamPolicy",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(resource)
+        resource = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1224,7 +1224,7 @@ pub async fn cloudresourcemanager_tag_values_tag_holds_create(
     let local_var_uri_str = format!(
         "{}/v3/{parent}/tagHolds",
         local_var_configuration.base_path,
-        parent = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(parent)
+        parent = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(parent)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1338,7 +1338,7 @@ pub async fn cloudresourcemanager_tag_values_tag_holds_delete(
     let local_var_uri_str = format!(
         "{}/v3/{name}",
         local_var_configuration.base_path,
-        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(name)
+        name = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(name)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::DELETE, local_var_uri_str.as_str());
@@ -1453,7 +1453,7 @@ pub async fn cloudresourcemanager_tag_values_tag_holds_list(
     let local_var_uri_str = format!(
         "{}/v3/{parent}/tagHolds",
         local_var_configuration.base_path,
-        parent = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(parent)
+        parent = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(parent)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1574,7 +1574,7 @@ pub async fn cloudresourcemanager_tag_values_test_iam_permissions(
     let local_var_uri_str = format!(
         "{}/v3/{resource}:testIamPermissions",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode(resource)
+        resource = crate::google_rest_apis::cloudresourcemanager_v3::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/addresses_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/addresses_api.rs
@@ -1116,7 +1116,7 @@ pub async fn compute_addresses_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/backend_buckets_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/backend_buckets_api.rs
@@ -1017,7 +1017,7 @@ pub async fn compute_backend_buckets_get_iam_policy(
         "{}/projects/{project}/global/backendBuckets/{resource}/getIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1619,7 +1619,7 @@ pub async fn compute_backend_buckets_set_iam_policy(
         "{}/projects/{project}/global/backendBuckets/{resource}/setIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1735,7 +1735,7 @@ pub async fn compute_backend_buckets_test_iam_permissions(
         "{}/projects/{project}/global/backendBuckets/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/backend_services_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/backend_services_api.rs
@@ -1463,7 +1463,7 @@ pub async fn compute_backend_services_get_iam_policy(
         "{}/projects/{project}/global/backendServices/{resource}/getIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -2203,7 +2203,7 @@ pub async fn compute_backend_services_set_iam_policy(
         "{}/projects/{project}/global/backendServices/{resource}/setIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -2437,7 +2437,7 @@ pub async fn compute_backend_services_test_iam_permissions(
         "{}/projects/{project}/global/backendServices/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/disks_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/disks_api.rs
@@ -1597,7 +1597,7 @@ pub async fn compute_disks_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -2214,7 +2214,7 @@ pub async fn compute_disks_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -2330,7 +2330,7 @@ pub async fn compute_disks_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -2808,7 +2808,7 @@ pub async fn compute_disks_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/external_vpn_gateways_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/external_vpn_gateways_api.rs
@@ -776,7 +776,7 @@ pub async fn compute_external_vpn_gateways_set_labels(
         "{}/projects/{project}/global/externalVpnGateways/{resource}/setLabels",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -892,7 +892,7 @@ pub async fn compute_external_vpn_gateways_test_iam_permissions(
         "{}/projects/{project}/global/externalVpnGateways/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/firewall_policies_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/firewall_policies_api.rs
@@ -1476,7 +1476,7 @@ pub async fn compute_firewall_policies_get_iam_policy(
     let local_var_uri_str = format!(
         "{}/locations/global/firewallPolicies/{resource}/getIamPolicy",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -2669,7 +2669,7 @@ pub async fn compute_firewall_policies_set_iam_policy(
     let local_var_uri_str = format!(
         "{}/locations/global/firewallPolicies/{resource}/setIamPolicy",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -2783,7 +2783,7 @@ pub async fn compute_firewall_policies_test_iam_permissions(
     let local_var_uri_str = format!(
         "{}/locations/global/firewallPolicies/{resource}/testIamPermissions",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/forwarding_rules_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/forwarding_rules_api.rs
@@ -1164,7 +1164,7 @@ pub async fn compute_forwarding_rules_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/global_addresses_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/global_addresses_api.rs
@@ -893,7 +893,7 @@ pub async fn compute_global_addresses_set_labels(
         "{}/projects/{project}/global/addresses/{resource}/setLabels",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/global_forwarding_rules_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/global_forwarding_rules_api.rs
@@ -936,7 +936,7 @@ pub async fn compute_global_forwarding_rules_set_labels(
         "{}/projects/{project}/global/forwardingRules/{resource}/setLabels",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/images_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/images_api.rs
@@ -963,7 +963,7 @@ pub async fn compute_images_get_iam_policy(
         "{}/projects/{project}/global/images/{resource}/getIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1452,7 +1452,7 @@ pub async fn compute_images_set_iam_policy(
         "{}/projects/{project}/global/images/{resource}/setIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1565,7 +1565,7 @@ pub async fn compute_images_set_labels(
         "{}/projects/{project}/global/images/{resource}/setLabels",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1679,7 +1679,7 @@ pub async fn compute_images_test_iam_permissions(
         "{}/projects/{project}/global/images/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/instance_templates_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/instance_templates_api.rs
@@ -764,7 +764,7 @@ pub async fn compute_instance_templates_get_iam_policy(
         "{}/projects/{project}/global/instanceTemplates/{resource}/getIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1130,7 +1130,7 @@ pub async fn compute_instance_templates_set_iam_policy(
         "{}/projects/{project}/global/instanceTemplates/{resource}/setIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1246,7 +1246,7 @@ pub async fn compute_instance_templates_test_iam_permissions(
         "{}/projects/{project}/global/instanceTemplates/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/instances_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/instances_api.rs
@@ -3584,7 +3584,7 @@ pub async fn compute_instances_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -5045,7 +5045,7 @@ pub async fn compute_instances_set_deletion_protection(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -5291,7 +5291,7 @@ pub async fn compute_instances_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -7340,7 +7340,7 @@ pub async fn compute_instances_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/instant_snapshots_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/instant_snapshots_api.rs
@@ -829,7 +829,7 @@ pub async fn compute_instant_snapshots_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1201,7 +1201,7 @@ pub async fn compute_instant_snapshots_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1317,7 +1317,7 @@ pub async fn compute_instant_snapshots_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1439,7 +1439,7 @@ pub async fn compute_instant_snapshots_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/interconnect_attachments_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/interconnect_attachments_api.rs
@@ -1134,7 +1134,7 @@ pub async fn compute_interconnect_attachments_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/interconnects_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/interconnects_api.rs
@@ -1201,7 +1201,7 @@ pub async fn compute_interconnects_set_labels(
         "{}/projects/{project}/global/interconnects/{resource}/setLabels",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/license_codes_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/license_codes_api.rs
@@ -238,7 +238,7 @@ pub async fn compute_license_codes_test_iam_permissions(
         "{}/projects/{project}/global/licenseCodes/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/licenses_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/licenses_api.rs
@@ -565,7 +565,7 @@ pub async fn compute_licenses_get_iam_policy(
         "{}/projects/{project}/global/licenses/{resource}/getIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -931,7 +931,7 @@ pub async fn compute_licenses_set_iam_policy(
         "{}/projects/{project}/global/licenses/{resource}/setIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1047,7 +1047,7 @@ pub async fn compute_licenses_test_iam_permissions(
         "{}/projects/{project}/global/licenses/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/machine_images_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/machine_images_api.rs
@@ -567,7 +567,7 @@ pub async fn compute_machine_images_get_iam_policy(
         "{}/projects/{project}/global/machineImages/{resource}/getIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -938,7 +938,7 @@ pub async fn compute_machine_images_set_iam_policy(
         "{}/projects/{project}/global/machineImages/{resource}/setIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1054,7 +1054,7 @@ pub async fn compute_machine_images_test_iam_permissions(
         "{}/projects/{project}/global/machineImages/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/mod.rs
@@ -191,3 +191,13 @@ pub mod zone_operations_api;
 pub mod zones_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/network_attachments_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/network_attachments_api.rs
@@ -831,7 +831,7 @@ pub async fn compute_network_attachments_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1324,7 +1324,7 @@ pub async fn compute_network_attachments_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1442,7 +1442,7 @@ pub async fn compute_network_attachments_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/network_endpoint_groups_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/network_endpoint_groups_api.rs
@@ -1485,7 +1485,7 @@ pub async fn compute_network_endpoint_groups_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/network_firewall_policies_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/network_firewall_policies_api.rs
@@ -1455,7 +1455,7 @@ pub async fn compute_network_firewall_policies_get_iam_policy(
         "{}/projects/{project}/global/firewallPolicies/{resource}/getIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -2426,7 +2426,7 @@ pub async fn compute_network_firewall_policies_set_iam_policy(
         "{}/projects/{project}/global/firewallPolicies/{resource}/setIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -2542,7 +2542,7 @@ pub async fn compute_network_firewall_policies_test_iam_permissions(
         "{}/projects/{project}/global/firewallPolicies/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/node_groups_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/node_groups_api.rs
@@ -1302,7 +1302,7 @@ pub async fn compute_node_groups_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1935,7 +1935,7 @@ pub async fn compute_node_groups_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -2295,7 +2295,7 @@ pub async fn compute_node_groups_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/node_templates_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/node_templates_api.rs
@@ -784,7 +784,7 @@ pub async fn compute_node_templates_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1156,7 +1156,7 @@ pub async fn compute_node_templates_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1274,7 +1274,7 @@ pub async fn compute_node_templates_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/packet_mirrorings_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/packet_mirrorings_api.rs
@@ -1119,7 +1119,7 @@ pub async fn compute_packet_mirrorings_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/region_backend_services_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/region_backend_services_api.rs
@@ -930,7 +930,7 @@ pub async fn compute_region_backend_services_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1561,7 +1561,7 @@ pub async fn compute_region_backend_services_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1801,7 +1801,7 @@ pub async fn compute_region_backend_services_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/region_disks_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/region_disks_api.rs
@@ -1398,7 +1398,7 @@ pub async fn compute_region_disks_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -2017,7 +2017,7 @@ pub async fn compute_region_disks_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -2133,7 +2133,7 @@ pub async fn compute_region_disks_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -2616,7 +2616,7 @@ pub async fn compute_region_disks_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/region_instant_snapshots_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/region_instant_snapshots_api.rs
@@ -630,7 +630,7 @@ pub async fn compute_region_instant_snapshots_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1003,7 +1003,7 @@ pub async fn compute_region_instant_snapshots_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1119,7 +1119,7 @@ pub async fn compute_region_instant_snapshots_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1241,7 +1241,7 @@ pub async fn compute_region_instant_snapshots_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/region_network_firewall_policies_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/region_network_firewall_policies_api.rs
@@ -1667,7 +1667,7 @@ pub async fn compute_region_network_firewall_policies_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -2658,7 +2658,7 @@ pub async fn compute_region_network_firewall_policies_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -2777,7 +2777,7 @@ pub async fn compute_region_network_firewall_policies_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/reservations_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/reservations_api.rs
@@ -877,7 +877,7 @@ pub async fn compute_reservations_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1369,7 +1369,7 @@ pub async fn compute_reservations_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1487,7 +1487,7 @@ pub async fn compute_reservations_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         zone = crate::google_rest_apis::compute_v1::apis::urlencode(zone),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/resource_policies_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/resource_policies_api.rs
@@ -831,7 +831,7 @@ pub async fn compute_resource_policies_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1328,7 +1328,7 @@ pub async fn compute_resource_policies_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1446,7 +1446,7 @@ pub async fn compute_resource_policies_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/security_policies_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/security_policies_api.rs
@@ -1944,7 +1944,7 @@ pub async fn compute_security_policies_set_labels(
         "{}/projects/{project}/global/securityPolicies/{resource}/setLabels",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/service_attachments_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/service_attachments_api.rs
@@ -831,7 +831,7 @@ pub async fn compute_service_attachments_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1324,7 +1324,7 @@ pub async fn compute_service_attachments_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1442,7 +1442,7 @@ pub async fn compute_service_attachments_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/snapshots_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/snapshots_api.rs
@@ -606,7 +606,7 @@ pub async fn compute_snapshots_get_iam_policy(
         "{}/projects/{project}/global/snapshots/{resource}/getIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -972,7 +972,7 @@ pub async fn compute_snapshots_set_iam_policy(
         "{}/projects/{project}/global/snapshots/{resource}/setIamPolicy",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1085,7 +1085,7 @@ pub async fn compute_snapshots_set_labels(
         "{}/projects/{project}/global/snapshots/{resource}/setLabels",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1201,7 +1201,7 @@ pub async fn compute_snapshots_test_iam_permissions(
         "{}/projects/{project}/global/snapshots/{resource}/testIamPermissions",
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/subnetworks_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/subnetworks_api.rs
@@ -1091,7 +1091,7 @@ pub async fn compute_subnetworks_get_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
@@ -1725,7 +1725,7 @@ pub async fn compute_subnetworks_set_iam_policy(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1965,7 +1965,7 @@ pub async fn compute_subnetworks_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/target_vpn_gateways_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/target_vpn_gateways_api.rs
@@ -954,7 +954,7 @@ pub async fn compute_target_vpn_gateways_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/vpn_gateways_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/vpn_gateways_api.rs
@@ -1153,7 +1153,7 @@ pub async fn compute_vpn_gateways_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1275,7 +1275,7 @@ pub async fn compute_vpn_gateways_test_iam_permissions(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/vpn_tunnels_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/compute_v1/apis/vpn_tunnels_api.rs
@@ -952,7 +952,7 @@ pub async fn compute_vpn_tunnels_set_labels(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::compute_v1::apis::urlencode(project),
         region = crate::google_rest_apis::compute_v1::apis::urlencode(region),
-        resource = crate::google_rest_apis::compute_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::compute_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/dns_v1/apis/managed_zones_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/dns_v1/apis/managed_zones_api.rs
@@ -728,7 +728,7 @@ pub async fn dns_managed_zones_get_iam_policy(
     let local_var_uri_str = format!(
         "{}/dns/v1/{resource}:getIamPolicy",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::dns_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::dns_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1066,7 +1066,7 @@ pub async fn dns_managed_zones_set_iam_policy(
     let local_var_uri_str = format!(
         "{}/dns/v1/{resource}:setIamPolicy",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::dns_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::dns_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
@@ -1176,7 +1176,7 @@ pub async fn dns_managed_zones_test_iam_permissions(
     let local_var_uri_str = format!(
         "{}/dns/v1/{resource}:testIamPermissions",
         local_var_configuration.base_path,
-        resource = crate::google_rest_apis::dns_v1::apis::urlencode(resource)
+        resource = crate::google_rest_apis::dns_v1::apis::urlencode_path(resource)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/dns_v1/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/dns_v1/apis/mod.rs
@@ -104,3 +104,13 @@ pub mod response_policies_api;
 pub mod response_policy_rules_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/dns_v1/apis/resource_record_sets_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/dns_v1/apis/resource_record_sets_api.rs
@@ -373,7 +373,7 @@ pub async fn dns_resource_record_sets_delete(
 
     let local_var_client = &local_var_configuration.client;
 
-    let local_var_uri_str = format!("{}/dns/v1/projects/{project}/managedZones/{managedZone}/rrsets/{name}/{type}", local_var_configuration.base_path, project=crate::google_rest_apis::dns_v1::apis::urlencode(project), managedZone=crate::google_rest_apis::dns_v1::apis::urlencode(managed_zone), name=crate::google_rest_apis::dns_v1::apis::urlencode(name), type=crate::google_rest_apis::dns_v1::apis::urlencode(r#type));
+    let local_var_uri_str = format!("{}/dns/v1/projects/{project}/managedZones/{managedZone}/rrsets/{name}/{type}", local_var_configuration.base_path, project=crate::google_rest_apis::dns_v1::apis::urlencode(project), managedZone=crate::google_rest_apis::dns_v1::apis::urlencode(managed_zone), name=crate::google_rest_apis::dns_v1::apis::urlencode_path(name), type=crate::google_rest_apis::dns_v1::apis::urlencode(r#type));
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::DELETE, local_var_uri_str.as_str());
 
@@ -481,7 +481,7 @@ pub async fn dns_resource_record_sets_get(
 
     let local_var_client = &local_var_configuration.client;
 
-    let local_var_uri_str = format!("{}/dns/v1/projects/{project}/managedZones/{managedZone}/rrsets/{name}/{type}", local_var_configuration.base_path, project=crate::google_rest_apis::dns_v1::apis::urlencode(project), managedZone=crate::google_rest_apis::dns_v1::apis::urlencode(managed_zone), name=crate::google_rest_apis::dns_v1::apis::urlencode(name), type=crate::google_rest_apis::dns_v1::apis::urlencode(r#type));
+    let local_var_uri_str = format!("{}/dns/v1/projects/{project}/managedZones/{managedZone}/rrsets/{name}/{type}", local_var_configuration.base_path, project=crate::google_rest_apis::dns_v1::apis::urlencode(project), managedZone=crate::google_rest_apis::dns_v1::apis::urlencode(managed_zone), name=crate::google_rest_apis::dns_v1::apis::urlencode_path(name), type=crate::google_rest_apis::dns_v1::apis::urlencode(r#type));
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
 
@@ -717,7 +717,7 @@ pub async fn dns_resource_record_sets_patch(
 
     let local_var_client = &local_var_configuration.client;
 
-    let local_var_uri_str = format!("{}/dns/v1/projects/{project}/managedZones/{managedZone}/rrsets/{name}/{type}", local_var_configuration.base_path, project=crate::google_rest_apis::dns_v1::apis::urlencode(project), managedZone=crate::google_rest_apis::dns_v1::apis::urlencode(managed_zone), name=crate::google_rest_apis::dns_v1::apis::urlencode(name), type=crate::google_rest_apis::dns_v1::apis::urlencode(r#type));
+    let local_var_uri_str = format!("{}/dns/v1/projects/{project}/managedZones/{managedZone}/rrsets/{name}/{type}", local_var_configuration.base_path, project=crate::google_rest_apis::dns_v1::apis::urlencode(project), managedZone=crate::google_rest_apis::dns_v1::apis::urlencode(managed_zone), name=crate::google_rest_apis::dns_v1::apis::urlencode_path(name), type=crate::google_rest_apis::dns_v1::apis::urlencode(r#type));
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::PATCH, local_var_uri_str.as_str());
 

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/fcm_v1/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/fcm_v1/apis/mod.rs
@@ -96,3 +96,13 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 pub mod projects_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/fcm_v1/apis/projects_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/fcm_v1/apis/projects_api.rs
@@ -77,7 +77,7 @@ pub async fn fcm_projects_messages_send(
     let local_var_uri_str = format!(
         "{}/v1/{parent}/messages:send",
         local_var_configuration.base_path,
-        parent = crate::google_rest_apis::fcm_v1::apis::urlencode(parent)
+        parent = crate::google_rest_apis::fcm_v1::apis::urlencode_path(parent)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/identitytoolkit_v3/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/identitytoolkit_v3/apis/mod.rs
@@ -96,3 +96,13 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 pub mod relyingparty_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/lustre_v1/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/lustre_v1/apis/mod.rs
@@ -96,3 +96,13 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 pub mod projects_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/lustre_v1/apis/projects_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/lustre_v1/apis/projects_api.rs
@@ -1298,7 +1298,7 @@ pub async fn lustre_projects_locations_list(
     let local_var_uri_str = format!(
         "{}/v1/{name}/locations",
         local_var_configuration.base_path,
-        name = crate::google_rest_apis::lustre_v1::apis::urlencode(name)
+        name = crate::google_rest_apis::lustre_v1::apis::urlencode_path(name)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/servicecontrol_v1/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/servicecontrol_v1/apis/mod.rs
@@ -96,3 +96,13 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 pub mod services_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/servicecontrol_v2/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/servicecontrol_v2/apis/mod.rs
@@ -96,3 +96,13 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 pub mod services_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/sqladmin_v1/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/sqladmin_v1/apis/mod.rs
@@ -105,3 +105,13 @@ pub mod tiers_api;
 pub mod users_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/sqladmin_v1/apis/users_api.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/sqladmin_v1/apis/users_api.rs
@@ -364,7 +364,7 @@ pub async fn sql_users_get(
         local_var_configuration.base_path,
         project = crate::google_rest_apis::sqladmin_v1::apis::urlencode(project),
         instance = crate::google_rest_apis::sqladmin_v1::apis::urlencode(instance),
-        name = crate::google_rest_apis::sqladmin_v1::apis::urlencode(name)
+        name = crate::google_rest_apis::sqladmin_v1::apis::urlencode_path(name)
     );
     let mut local_var_req_builder =
         local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());

--- a/gcloud-sdk/src/rest_apis/google_rest_apis/storage_v1/apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/google_rest_apis/storage_v1/apis/mod.rs
@@ -107,3 +107,13 @@ pub mod operations_api;
 pub mod projects_api;
 
 pub mod configuration;
+
+/// Encodes a path parameter that holds a full resource name (e.g. `projects/my-project`),
+/// preserving `/` as a path separator while encoding each segment.
+pub fn urlencode_path<T: AsRef<str>>(s: T) -> String {
+    s.as_ref()
+        .split('/')
+        .map(urlencode)
+        .collect::<Vec<String>>()
+        .join("/")
+}

--- a/gcloud-sdk/src/rest_apis/mod.rs
+++ b/gcloud-sdk/src/rest_apis/mod.rs
@@ -11,3 +11,22 @@ mod rest_api_client;
 pub use rest_api_client::*;
 
 pub mod google_rest_apis;
+
+#[cfg(all(test, feature = "google-rest-fcm-v1"))]
+mod tests {
+    use super::google_rest_apis::fcm_v1::{urlencode, urlencode_path};
+
+    #[test]
+    fn urlencode_path_preserves_resource_name_slashes() {
+        assert_eq!(
+            urlencode_path("projects/my-project-id"),
+            "projects/my-project-id"
+        );
+        assert_eq!(urlencode_path("projects/a b"), "projects/a+b");
+        // plain urlencode still encodes slashes (required for e.g. GCS object names)
+        assert_eq!(
+            urlencode("projects/my-project-id"),
+            "projects%2Fmy-project-id"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #251. Resource-name path params (`parent`/`name`/`resource`, e.g. `projects/my-project-id`) were encoded as `projects%2Fmy-project-id`, causing 404s. Adds a slash-preserving `urlencode_path` helper (wired into `generate-all.sh` for future regenerations). GCS object paths keep full encoding.