### PR TITLE
feat(performance): Cache validated headers and the auth header in the gRPC middleware

### DIFF
--- a/examples/bigquery-storage-read-client/src/main.rs
+++ b/examples/bigquery-storage-read-client/src/main.rs
@@ -42,6 +42,7 @@ async fn read_stream(
     let read_rows_request = ReadRowsRequest {
         read_stream: stream_name.clone(),
         offset: 0,
+        ..Default::default()
     };
 
     let messages = read_client
@@ -95,7 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             None,
         )
         .await?
-        .amend_user_agent("gcloud-sdk-rs-example/0.1.0".to_string());
+        .amend_user_agent("gcloud-sdk-rs-example/0.1.0".to_string())?;
 
     let read_session = ReadSession {
         data_format: DataFormat::Arrow as i32,

--- a/gcloud-sdk/src/api_client.rs
+++ b/gcloud-sdk/src/api_client.rs
@@ -71,8 +71,9 @@ where
         let token_generator =
             GoogleAuthTokenGenerator::new(token_source_type, token_scopes).await?;
 
-        let mut middleware = GoogleAuthMiddlewareLayer::new(token_generator, cloud_resource_prefix);
-        middleware.set_additional_headers(additional_headers);
+        let mut middleware =
+            GoogleAuthMiddlewareLayer::new(token_generator, cloud_resource_prefix)?;
+        middleware.set_additional_headers(additional_headers)?;
 
         Self::with_token_source_and_middleware(builder, google_api_url, middleware).await
     }
@@ -90,7 +91,7 @@ where
         Ok(Self {
             builder,
             service,
-            _ph: PhantomData::default(),
+            _ph: PhantomData,
         })
     }
 
@@ -98,14 +99,17 @@ where
         self.builder.create_client(self.service.clone())
     }
 
-    pub fn amend_user_agent(mut self, user_agent: String) -> Self {
-        self.service.append_user_agent(user_agent);
-        self
+    pub fn amend_user_agent(mut self, user_agent: String) -> crate::error::Result<Self> {
+        self.service.append_user_agent(user_agent)?;
+        Ok(self)
     }
 
-    pub fn amend_x_goog_api_client(mut self, x_goog_api_client: String) -> Self {
-        self.service.append_x_goog_api_client(x_goog_api_client);
-        self
+    pub fn amend_x_goog_api_client(
+        mut self,
+        x_goog_api_client: String,
+    ) -> crate::error::Result<Self> {
+        self.service.append_x_goog_api_client(x_goog_api_client)?;
+        Ok(self)
     }
 }
 

--- a/gcloud-sdk/src/api_client.rs
+++ b/gcloud-sdk/src/api_client.rs
@@ -73,7 +73,7 @@ where
 
         let mut middleware =
             GoogleAuthMiddlewareLayer::new(token_generator, cloud_resource_prefix)?;
-        middleware.set_additional_headers(additional_headers)?;
+        middleware.set_additional_headers(additional_headers);
 
         Self::with_token_source_and_middleware(builder, google_api_url, middleware).await
     }

--- a/gcloud-sdk/src/error.rs
+++ b/gcloud-sdk/src/error.rs
@@ -2,6 +2,7 @@ use std::{convert::From, fmt};
 
 /// Represents the details of the [`Error`](struct.Error.html)
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Errors that can possibly occur while accessing an HTTP server.
     Http(reqwest::Error),
@@ -28,8 +29,9 @@ pub enum ErrorKind {
     GrpcStatus(tonic::transport::Error),
     UrlError(hyper::http::uri::InvalidUri),
     ExternalCredsSourceError(String),
-    #[doc(hidden)]
-    __Nonexhaustive,
+    /// A header value built from user input (user agent, headers, the token itself)
+    /// failed HTTP header validation (e.g. contained a control character).
+    HeaderValue(hyper::header::InvalidHeaderValue),
 }
 
 /// Details of an authentication failure (see [`ErrorKind::Auth`]).
@@ -116,7 +118,7 @@ impl fmt::Display for Error {
             TonicMetadata(ref e) => write!(f, "Tonic metadata error: {}", e),
             UrlError(ref e) => write!(f, "Url error: {}", e),
             ExternalCredsSourceError(ref e) => write!(f, "External creds source error: {}", e),
-            __Nonexhaustive => write!(f, "unknown error"),
+            HeaderValue(ref e) => write!(f, "invalid header value: {}", e),
         }
     }
 }
@@ -156,6 +158,12 @@ impl From<tonic::metadata::errors::InvalidMetadataValue> for Error {
 impl From<hyper::http::uri::InvalidUri> for Error {
     fn from(e: hyper::http::uri::InvalidUri) -> Self {
         ErrorKind::UrlError(e).into()
+    }
+}
+
+impl From<hyper::header::InvalidHeaderValue> for Error {
+    fn from(e: hyper::header::InvalidHeaderValue) -> Self {
+        ErrorKind::HeaderValue(e).into()
     }
 }
 

--- a/gcloud-sdk/src/middleware.rs
+++ b/gcloud-sdk/src/middleware.rs
@@ -30,7 +30,7 @@ fn default_headers(cloud_resource_prefix: Option<String>) -> crate::error::Resul
 }
 
 /// Appends `extra` to whatever `name` currently holds in `headers` (space separated),
-/// or sets it outright if absent, matching the historical "amend" behaviour.
+/// or sets it outright if absent.
 fn append_header_value(
     headers: &HeaderMap,
     name: &HeaderName,
@@ -41,16 +41,6 @@ fn append_header_value(
         None => extra.to_string(),
     };
     Ok(HeaderValue::from_str(&combined)?)
-}
-
-/// Merges headers whose name survived the http crate's multi-value iteration
-/// (i.e. `insert`, last value per name wins), matching historical behaviour.
-fn merge_headers(target: &mut HeaderMap, additional_headers: HeaderMap) {
-    for (maybe_name, value) in additional_headers {
-        if let Some(name) = maybe_name {
-            target.insert(name, value);
-        }
-    }
 }
 
 #[derive(Clone)]
@@ -110,12 +100,8 @@ impl<T> GoogleAuthMiddlewareService<T> {
         Ok(())
     }
 
-    pub fn set_additional_headers(
-        &mut self,
-        additional_headers: HeaderMap,
-    ) -> crate::error::Result<()> {
-        merge_headers(Arc::make_mut(&mut self.headers), additional_headers);
-        Ok(())
+    pub fn set_additional_headers(&mut self, additional_headers: HeaderMap) {
+        Arc::make_mut(&mut self.headers).extend(additional_headers);
     }
 }
 
@@ -152,9 +138,18 @@ where
 
             let req_headers = req.headers_mut();
             req_headers.insert(hyper::header::AUTHORIZATION, authorization);
-            for (name, value) in headers.iter() {
-                req_headers.insert(name.clone(), value.clone());
+            // Each name in `headers` fully replaces whatever the request already carries
+            // under it (multi-valued or not); `iter()` yields one pair per value, so the
+            // names are cleared first and then appended rather than repeatedly `insert`ed,
+            // which would silently drop every value but the last for a repeated name.
+            for name in headers.keys() {
+                req_headers.remove(name);
             }
+            req_headers.extend(
+                headers
+                    .iter()
+                    .map(|(name, value)| (name.clone(), value.clone())),
+            );
 
             let req_uri = req.uri().clone();
             inner
@@ -215,12 +210,8 @@ impl GoogleAuthMiddlewareLayer {
         Ok(self)
     }
 
-    pub fn set_additional_headers(
-        &mut self,
-        additional_headers: HeaderMap,
-    ) -> crate::error::Result<()> {
-        merge_headers(Arc::make_mut(&mut self.headers), additional_headers);
-        Ok(())
+    pub fn set_additional_headers(&mut self, additional_headers: HeaderMap) {
+        Arc::make_mut(&mut self.headers).extend(additional_headers);
     }
 }
 
@@ -477,7 +468,7 @@ mod tests {
                 .unwrap();
         let mut test_headers = hyper::HeaderMap::new();
         test_headers.insert("x-test-header", "test-value".parse().unwrap());
-        service.set_additional_headers(test_headers).unwrap();
+        service.set_additional_headers(test_headers);
 
         let req = Request::builder()
             .uri("http://example.com")
@@ -491,5 +482,42 @@ mod tests {
             captured_req.headers().get("x-test-header").unwrap(),
             "test-value"
         );
+    }
+
+    #[tokio::test]
+    async fn additional_headers_keep_every_value_of_a_repeated_name() {
+        let token_generator = GoogleAuthTokenGenerator::new(
+            TokenSourceType::ExternalSource(Box::new(DummySource)),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let dummy_service = DummyService { tx: Arc::new(tx) };
+        let mut service =
+            GoogleAuthMiddlewareService::new(dummy_service, Arc::new(token_generator), None)
+                .unwrap();
+
+        let mut test_headers = hyper::HeaderMap::new();
+        test_headers.append("x-multi", "first".parse().unwrap());
+        test_headers.append("x-multi", "second".parse().unwrap());
+        service.set_additional_headers(test_headers);
+
+        let req = Request::builder()
+            .uri("http://example.com")
+            .body("".to_string())
+            .unwrap();
+
+        tower::Service::call(&mut service, req).await.unwrap();
+
+        let captured_req = rx.recv().await.unwrap();
+        let values: Vec<&str> = captured_req
+            .headers()
+            .get_all("x-multi")
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert_eq!(values, vec!["first", "second"]);
     }
 }

--- a/gcloud-sdk/src/middleware.rs
+++ b/gcloud-sdk/src/middleware.rs
@@ -1,5 +1,6 @@
 use crate::token_source::auth_token_generator::GoogleAuthTokenGenerator;
 use futures::{Future, TryFutureExt};
+use hyper::header::{HeaderMap, HeaderName, HeaderValue, USER_AGENT};
 use jiff::Timestamp;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -9,56 +10,112 @@ use tower::Service;
 use tower_layer::Layer;
 use tracing::*;
 
-#[derive(Clone)]
-pub struct GoogleAuthMiddlewareService<T>
-where
-    T: Clone,
-{
-    google_service: Option<T>,
-    token_generator: Arc<GoogleAuthTokenGenerator>,
-    cloud_resource_prefix: Option<String>,
-    user_agent: String,
-    x_goog_api_client: String,
-    additional_headers: hyper::header::HeaderMap,
+const X_GOOG_API_CLIENT: HeaderName = HeaderName::from_static("x-goog-api-client");
+const GOOGLE_CLOUD_RESOURCE_PREFIX: HeaderName =
+    HeaderName::from_static("google-cloud-resource-prefix");
+
+fn default_headers(cloud_resource_prefix: Option<String>) -> crate::error::Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    let default_agent =
+        HeaderValue::from_static(concat!("gcloud-sdk-rs/", env!("CARGO_PKG_VERSION")));
+    headers.insert(USER_AGENT, default_agent.clone());
+    headers.insert(X_GOOG_API_CLIENT, default_agent);
+    if let Some(prefix) = cloud_resource_prefix {
+        headers.insert(
+            GOOGLE_CLOUD_RESOURCE_PREFIX,
+            HeaderValue::from_str(&prefix)?,
+        );
+    }
+    Ok(headers)
 }
 
-impl<T> GoogleAuthMiddlewareService<T>
-where
-    T: Clone,
-{
+/// Appends `extra` to whatever `name` currently holds in `headers` (space separated),
+/// or sets it outright if absent, matching the historical "amend" behaviour.
+fn append_header_value(
+    headers: &HeaderMap,
+    name: &HeaderName,
+    extra: &str,
+) -> crate::error::Result<HeaderValue> {
+    let combined = match headers.get(name).and_then(|v| v.to_str().ok()) {
+        Some(current) => format!("{current} {extra}"),
+        None => extra.to_string(),
+    };
+    Ok(HeaderValue::from_str(&combined)?)
+}
+
+/// Merges headers whose name survived the http crate's multi-value iteration
+/// (i.e. `insert`, last value per name wins), matching historical behaviour.
+fn merge_headers(target: &mut HeaderMap, additional_headers: HeaderMap) {
+    for (maybe_name, value) in additional_headers {
+        if let Some(name) = maybe_name {
+            target.insert(name, value);
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct GoogleAuthMiddlewareService<T> {
+    inner: T,
+    token_generator: Arc<GoogleAuthTokenGenerator>,
+    /// Every header added to each request except `authorization`, already validated.
+    headers: Arc<HeaderMap>,
+}
+
+impl<T> GoogleAuthMiddlewareService<T> {
     pub fn new(
         service: T,
         token_generator: Arc<GoogleAuthTokenGenerator>,
         cloud_resource_prefix: Option<String>,
-    ) -> GoogleAuthMiddlewareService<T> {
-        GoogleAuthMiddlewareService {
-            google_service: Some(service),
+    ) -> crate::error::Result<GoogleAuthMiddlewareService<T>> {
+        Ok(GoogleAuthMiddlewareService {
+            inner: service,
             token_generator,
-            cloud_resource_prefix,
-            user_agent: format!("gcloud-sdk-rs/{}", env!("CARGO_PKG_VERSION")),
-            x_goog_api_client: format!("gcloud-sdk-rs/{}", env!("CARGO_PKG_VERSION")),
-            additional_headers: hyper::header::HeaderMap::new(),
-        }
+            headers: Arc::new(default_headers(cloud_resource_prefix)?),
+        })
     }
 
-    pub fn set_user_agent(&mut self, user_agent: String) {
-        self.user_agent = user_agent;
+    pub fn set_user_agent(&mut self, user_agent: String) -> crate::error::Result<()> {
+        let value = HeaderValue::from_str(&user_agent)?;
+        Arc::make_mut(&mut self.headers).insert(USER_AGENT, value);
+        Ok(())
     }
 
-    pub fn set_x_goog_api_client(&mut self, x_goog_api_client: String) {
-        self.x_goog_api_client = x_goog_api_client;
+    pub fn set_x_goog_api_client(&mut self, x_goog_api_client: String) -> crate::error::Result<()> {
+        let value = HeaderValue::from_str(&x_goog_api_client)?;
+        Arc::make_mut(&mut self.headers).insert(X_GOOG_API_CLIENT, value);
+        Ok(())
     }
 
-    pub fn append_user_agent(&mut self, user_agent: String) {
-        self.user_agent = format!("{} {}", self.user_agent, user_agent);
+    pub fn set_cloud_resource_prefix(
+        &mut self,
+        cloud_resource_prefix: String,
+    ) -> crate::error::Result<()> {
+        let value = HeaderValue::from_str(&cloud_resource_prefix)?;
+        Arc::make_mut(&mut self.headers).insert(GOOGLE_CLOUD_RESOURCE_PREFIX, value);
+        Ok(())
     }
 
-    pub fn append_x_goog_api_client(&mut self, x_goog_api_client: String) {
-        self.x_goog_api_client = format!("{} {}", self.x_goog_api_client, x_goog_api_client);
+    pub fn append_user_agent(&mut self, user_agent: String) -> crate::error::Result<()> {
+        let value = append_header_value(&self.headers, &USER_AGENT, &user_agent)?;
+        Arc::make_mut(&mut self.headers).insert(USER_AGENT, value);
+        Ok(())
     }
 
-    pub fn set_additional_headers(&mut self, additional_headers: hyper::HeaderMap) {
-        self.additional_headers = additional_headers;
+    pub fn append_x_goog_api_client(
+        &mut self,
+        x_goog_api_client: String,
+    ) -> crate::error::Result<()> {
+        let value = append_header_value(&self.headers, &X_GOOG_API_CLIENT, &x_goog_api_client)?;
+        Arc::make_mut(&mut self.headers).insert(X_GOOG_API_CLIENT, value);
+        Ok(())
+    }
+
+    pub fn set_additional_headers(
+        &mut self,
+        additional_headers: HeaderMap,
+    ) -> crate::error::Result<()> {
+        merge_headers(Arc::make_mut(&mut self.headers), additional_headers);
+        Ok(())
     }
 }
 
@@ -76,127 +133,106 @@ where
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if let Some(ref mut google_service) = self.google_service.as_mut() {
-            google_service.poll_ready(cx).map_err(|e| e.into())
-        } else {
-            Poll::Pending
-        }
+        self.inner.poll_ready(cx).map_err(Into::into)
     }
 
     fn call(&mut self, mut req: hyper::Request<RequestBody>) -> Self::Future {
-        let generator = self.token_generator.clone();
-        let cloud_resource_prefix = self.cloud_resource_prefix.clone();
-        let user_agent = self.user_agent.clone();
-        let x_goog_api_client = self.x_goog_api_client.clone();
-        let additional_headers = self.additional_headers.clone();
+        let generator = Arc::clone(&self.token_generator);
+        let headers = Arc::clone(&self.headers);
 
-        if let Some(mut google_service) = self.google_service.take() {
-            self.google_service = Some(google_service.clone());
-            Box::pin(async move {
-                let begin_time = Timestamp::now();
-                let token = generator.create_token().await.map_err(Box::new)?;
-                let token_generated_time = Timestamp::now();
-                let headers = req.headers_mut();
-                headers.insert("authorization", token.header_value().parse()?);
-                if let Some(cloud_resource_prefix_value) = cloud_resource_prefix {
-                    headers.insert(
-                        "google-cloud-resource-prefix",
-                        cloud_resource_prefix_value.parse()?,
+        // tower's documented idiom for a `Clone` inner service: the instance we already
+        // polled ready goes into the future, and the service keeps a fresh clone.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move {
+            let begin_time = Timestamp::now();
+            let authorization = generator.authorization_header().await.map_err(Box::new)?;
+            let token_generated_time = Timestamp::now();
+
+            let req_headers = req.headers_mut();
+            req_headers.insert(hyper::header::AUTHORIZATION, authorization);
+            for (name, value) in headers.iter() {
+                req_headers.insert(name.clone(), value.clone());
+            }
+
+            let req_uri = req.uri().clone();
+            inner
+                .call(req)
+                .map_ok(|x| {
+                    let finished_time = Timestamp::now();
+                    debug!(
+                        %req_uri,
+                        "OK: took {}ms (incl. token gen: {}ms)",
+                        finished_time.duration_since(begin_time).as_millis(),
+                        token_generated_time.duration_since(begin_time).as_millis()
                     );
-                }
-                headers.insert(hyper::header::USER_AGENT, user_agent.parse()?);
-                headers.insert("x-goog-api-client", x_goog_api_client.parse()?);
-
-                for (maybe_k, v) in additional_headers.into_iter() {
-                    if let Some(k) = maybe_k {
-                        headers.insert(k, v);
-                    }
-                }
-
-                let req_uri_str = req.uri().to_string();
-                google_service
-                    .call(req)
-                    .map_ok(|x| {
-                        let finished_time = Timestamp::now();
-                        debug!(
-                            "OK: {} took {}ms (incl. token gen: {}ms)",
-                            req_uri_str,
-                            finished_time.duration_since(begin_time).as_millis(),
-                            token_generated_time.duration_since(begin_time).as_millis()
-                        );
-                        x
-                    })
-                    .await
-                    .map_err(|e| {
-                        let finished_time = Timestamp::now();
-                        error!(
-                            "Err: {} took {}ms (incl. token gen: {}ms)",
-                            req_uri_str,
-                            finished_time.duration_since(begin_time).as_millis(),
-                            token_generated_time.duration_since(begin_time).as_millis()
-                        );
-                        e.into()
-                    })
-            })
-        } else {
-            panic!("Should never happen, system error");
-        }
+                    x
+                })
+                .await
+                .map_err(|e| {
+                    let finished_time = Timestamp::now();
+                    error!(
+                        %req_uri,
+                        "Err: took {}ms (incl. token gen: {}ms)",
+                        finished_time.duration_since(begin_time).as_millis(),
+                        token_generated_time.duration_since(begin_time).as_millis()
+                    );
+                    e.into()
+                })
+        })
     }
 }
 
 pub struct GoogleAuthMiddlewareLayer {
-    pub token_generator: Arc<GoogleAuthTokenGenerator>,
-    pub cloud_resource_prefix: Option<String>,
-    pub user_agent: String,
-    pub x_goog_api_client: String,
-    pub additional_headers: hyper::header::HeaderMap,
+    token_generator: Arc<GoogleAuthTokenGenerator>,
+    headers: Arc<HeaderMap>,
 }
 
 impl GoogleAuthMiddlewareLayer {
     pub fn new(
         token_generator: GoogleAuthTokenGenerator,
         cloud_resource_prefix: Option<String>,
-    ) -> Self {
-        GoogleAuthMiddlewareLayer {
+    ) -> crate::error::Result<Self> {
+        Ok(GoogleAuthMiddlewareLayer {
             token_generator: Arc::new(token_generator),
-            cloud_resource_prefix,
-            user_agent: format!("gcloud-sdk-rs/{}", env!("CARGO_PKG_VERSION")),
-            x_goog_api_client: format!("gcloud-sdk-rs/{}", env!("CARGO_PKG_VERSION")),
-            additional_headers: hyper::header::HeaderMap::new(),
-        }
+            headers: Arc::new(default_headers(cloud_resource_prefix)?),
+        })
     }
 
-    pub fn amend_user_agent(mut self, user_agent: String) -> Self {
-        self.user_agent = format!("{} {}", self.user_agent, user_agent);
-        self
+    pub fn amend_user_agent(mut self, user_agent: String) -> crate::error::Result<Self> {
+        let value = append_header_value(&self.headers, &USER_AGENT, &user_agent)?;
+        Arc::make_mut(&mut self.headers).insert(USER_AGENT, value);
+        Ok(self)
     }
 
-    pub fn amend_x_goog_api_client(mut self, x_goog_api_client: String) -> Self {
-        self.x_goog_api_client = format!("{} {}", self.x_goog_api_client, x_goog_api_client);
-        self
+    pub fn amend_x_goog_api_client(
+        mut self,
+        x_goog_api_client: String,
+    ) -> crate::error::Result<Self> {
+        let value = append_header_value(&self.headers, &X_GOOG_API_CLIENT, &x_goog_api_client)?;
+        Arc::make_mut(&mut self.headers).insert(X_GOOG_API_CLIENT, value);
+        Ok(self)
     }
 
-    pub fn set_additional_headers(&mut self, additional_headers: hyper::HeaderMap) {
-        self.additional_headers = additional_headers;
+    pub fn set_additional_headers(
+        &mut self,
+        additional_headers: HeaderMap,
+    ) -> crate::error::Result<()> {
+        merge_headers(Arc::make_mut(&mut self.headers), additional_headers);
+        Ok(())
     }
 }
 
-impl<S> Layer<S> for GoogleAuthMiddlewareLayer
-where
-    S: Clone,
-{
+impl<S> Layer<S> for GoogleAuthMiddlewareLayer {
     type Service = GoogleAuthMiddlewareService<S>;
 
     fn layer(&self, service: S) -> GoogleAuthMiddlewareService<S> {
-        let mut middleware_service = GoogleAuthMiddlewareService::new(
-            service,
-            self.token_generator.clone(),
-            self.cloud_resource_prefix.clone(),
-        );
-        middleware_service.set_user_agent(self.user_agent.clone());
-        middleware_service.set_x_goog_api_client(self.x_goog_api_client.clone());
-        middleware_service.set_additional_headers(self.additional_headers.clone());
-        middleware_service
+        GoogleAuthMiddlewareService {
+            inner: service,
+            token_generator: Arc::clone(&self.token_generator),
+            headers: Arc::clone(&self.headers),
+        }
     }
 }
 
@@ -261,7 +297,8 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let dummy_service = DummyService { tx: Arc::new(tx) };
         let mut service =
-            GoogleAuthMiddlewareService::new(dummy_service, Arc::new(token_generator), None);
+            GoogleAuthMiddlewareService::new(dummy_service, Arc::new(token_generator), None)
+                .unwrap();
 
         let req = Request::builder()
             .uri("http://example.com")
@@ -290,6 +327,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn authorization_header_is_marked_sensitive() {
+        let token_generator = GoogleAuthTokenGenerator::new(
+            TokenSourceType::ExternalSource(Box::new(DummySource)),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let dummy_service = DummyService { tx: Arc::new(tx) };
+        let mut service =
+            GoogleAuthMiddlewareService::new(dummy_service, Arc::new(token_generator), None)
+                .unwrap();
+
+        let req = Request::builder()
+            .uri("http://example.com")
+            .body("".to_string())
+            .unwrap();
+
+        tower::Service::call(&mut service, req).await.unwrap();
+
+        let captured_req = rx.recv().await.unwrap();
+        assert!(captured_req
+            .headers()
+            .get("authorization")
+            .unwrap()
+            .is_sensitive());
+    }
+
+    #[tokio::test]
     async fn test_headers_amend() {
         let token_generator = GoogleAuthTokenGenerator::new(
             TokenSourceType::ExternalSource(Box::new(DummySource)),
@@ -302,8 +369,11 @@ mod tests {
         let dummy_service = DummyService { tx: Arc::new(tx) };
 
         let layer = GoogleAuthMiddlewareLayer::new(token_generator, None)
+            .unwrap()
             .amend_user_agent("extra-ua".to_string())
-            .amend_x_goog_api_client("extra-client".to_string());
+            .unwrap()
+            .amend_x_goog_api_client("extra-client".to_string())
+            .unwrap();
 
         let mut service = layer.layer(dummy_service);
 
@@ -332,6 +402,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invalid_user_agent_is_rejected_at_setter() {
+        let token_generator = GoogleAuthTokenGenerator::new(
+            TokenSourceType::ExternalSource(Box::new(DummySource)),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let layer_result = GoogleAuthMiddlewareLayer::new(token_generator, None)
+            .unwrap()
+            .amend_user_agent("bad\nvalue".to_string());
+
+        match layer_result {
+            Err(e) => assert!(matches!(
+                e.into_kind(),
+                crate::error::ErrorKind::HeaderValue(_)
+            )),
+            Ok(_) => panic!("expected an invalid header value to be rejected"),
+        }
+    }
+
+    #[tokio::test]
+    async fn amended_clone_does_not_change_sibling() {
+        let token_generator = GoogleAuthTokenGenerator::new(
+            TokenSourceType::ExternalSource(Box::new(DummySource)),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let dummy_service = DummyService { tx: Arc::new(tx) };
+        let base_service =
+            GoogleAuthMiddlewareService::new(dummy_service, Arc::new(token_generator), None)
+                .unwrap();
+
+        let mut amended = base_service.clone();
+        amended.append_user_agent("extra".to_string()).unwrap();
+
+        let mut sibling = base_service.clone();
+
+        let req = Request::builder()
+            .uri("http://example.com")
+            .body("".to_string())
+            .unwrap();
+
+        tower::Service::call(&mut sibling, req).await.unwrap();
+
+        let captured_req = rx.recv().await.unwrap();
+        let expected_default = format!("gcloud-sdk-rs/{}", env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            captured_req
+                .headers()
+                .get(hyper::header::USER_AGENT)
+                .unwrap(),
+            expected_default.as_str()
+        );
+    }
+
+    #[tokio::test]
     async fn test_additional_headers() {
         let token_generator = GoogleAuthTokenGenerator::new(
             TokenSourceType::ExternalSource(Box::new(DummySource)),
@@ -343,10 +473,11 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let dummy_service = DummyService { tx: Arc::new(tx) };
         let mut service =
-            GoogleAuthMiddlewareService::new(dummy_service, Arc::new(token_generator), None);
+            GoogleAuthMiddlewareService::new(dummy_service, Arc::new(token_generator), None)
+                .unwrap();
         let mut test_headers = hyper::HeaderMap::new();
         test_headers.insert("x-test-header", "test-value".parse().unwrap());
-        service.set_additional_headers(test_headers);
+        service.set_additional_headers(test_headers).unwrap();
 
         let req = Request::builder()
             .uri("http://example.com")

--- a/gcloud-sdk/src/rest_apis/rest_api_client.rs
+++ b/gcloud-sdk/src/rest_apis/rest_api_client.rs
@@ -41,8 +41,8 @@ impl GoogleRestApi {
         &self,
         request: RequestBuilder,
     ) -> crate::error::Result<RequestBuilder> {
-        let token = self.token_generator.create_token().await?;
-        Ok(request.header(reqwest::header::AUTHORIZATION, token.header_value()))
+        let authorization = self.token_generator.authorization_header().await?;
+        Ok(request.header(reqwest::header::AUTHORIZATION, authorization))
     }
 
     pub async fn get<U: IntoUrl>(&self, url: U) -> crate::error::Result<RequestBuilder> {

--- a/gcloud-sdk/src/token_source/auth_token_generator.rs
+++ b/gcloud-sdk/src/token_source/auth_token_generator.rs
@@ -1,14 +1,32 @@
-use std::sync::Arc;
-
+use hyper::header::HeaderValue;
 use jiff::{SignedDuration, Timestamp};
 use tokio::sync::RwLock;
 
 use crate::token_source::*;
 use tracing::*;
 
+/// A token together with its pre-validated `authorization` header value, so that
+/// serving a cache hit never re-parses or re-allocates the header.
+#[derive(Clone)]
+struct CachedToken {
+    token: Token,
+    authorization: HeaderValue,
+}
+
+impl CachedToken {
+    fn from_token(token: Token) -> crate::error::Result<Self> {
+        let mut authorization = HeaderValue::from_str(&token.header_value())?;
+        authorization.set_sensitive(true);
+        Ok(Self {
+            token,
+            authorization,
+        })
+    }
+}
+
 pub struct GoogleAuthTokenGenerator {
     token_source: BoxSource,
-    cached_token: Arc<RwLock<Option<Token>>>,
+    cached_token: RwLock<Option<CachedToken>>,
 }
 
 impl GoogleAuthTokenGenerator {
@@ -20,7 +38,7 @@ impl GoogleAuthTokenGenerator {
 
         Ok(GoogleAuthTokenGenerator {
             token_source,
-            cached_token: Arc::new(RwLock::new(None)),
+            cached_token: RwLock::new(None),
         })
     }
 
@@ -30,7 +48,17 @@ impl GoogleAuthTokenGenerator {
     }
 
     pub async fn create_token(&self) -> crate::error::Result<Token> {
-        let existing_token: Option<Token> = {
+        self.refreshed().await.map(|cached| cached.token)
+    }
+
+    /// The `authorization` header value for the current token, already validated
+    /// and marked sensitive; cloning it is a `Bytes` refcount bump, not an allocation.
+    pub async fn authorization_header(&self) -> crate::error::Result<HeaderValue> {
+        self.refreshed().await.map(|cached| cached.authorization)
+    }
+
+    async fn refreshed(&self) -> crate::error::Result<CachedToken> {
+        let existing_token: Option<CachedToken> = {
             let read_state = self.cached_token.read().await;
             read_state.clone()
         };
@@ -39,28 +67,83 @@ impl GoogleAuthTokenGenerator {
 
         match existing_token {
             // Give a bit more time for network call
-            Some(token) if token.expiry.gt(&now.add(SignedDuration::from_secs(15))) => Ok(token),
+            Some(cached)
+                if cached
+                    .token
+                    .expiry
+                    .gt(&now.add(SignedDuration::from_secs(15))) =>
+            {
+                Ok(cached)
+            }
             _ => {
-                let new_token = {
+                let new_cached = {
                     let mut write_token = self.cached_token.write().await;
 
                     match write_token.as_ref() {
-                        Some(updated_token) if updated_token.expiry.gt(&now) => {
-                            updated_token.clone()
+                        Some(updated_cached) if updated_cached.token.expiry.gt(&now) => {
+                            updated_cached.clone()
                         }
                         _ => {
                             let new_token = self.token_source.token().await?;
-                            *write_token = Some(new_token.clone());
                             debug!(
                                 "Created a new Google OAuth token. Type: {}. Expiring: {}.",
                                 new_token.token_type, new_token.expiry,
                             );
-                            new_token
+                            let new_cached = CachedToken::from_token(new_token)?;
+                            *write_token = Some(new_cached.clone());
+                            new_cached
                         }
                     }
                 };
-                Ok(new_token)
+                Ok(new_cached)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::token_source::Source;
+    use async_trait::async_trait;
+    use secret_vault_value::SecretValue;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    struct CountingSource {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Source for CountingSource {
+        async fn token(&self) -> crate::error::Result<Token> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Token {
+                token_type: "Bearer".to_string(),
+                token: SecretValue::from("cached-token"),
+                expiry: Timestamp::now() + SignedDuration::from_hours(1),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn authorization_header_reuses_cached_token() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let source = CountingSource {
+            calls: calls.clone(),
+        };
+        let generator = GoogleAuthTokenGenerator::new(
+            TokenSourceType::ExternalSource(Box::new(source)),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let first = generator.authorization_header().await.unwrap();
+        let second = generator.authorization_header().await.unwrap();
+
+        assert_eq!(first, second);
+        assert!(first.is_sensitive());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/gcloud-sdk/src/token_source/auth_token_generator.rs
+++ b/gcloud-sdk/src/token_source/auth_token_generator.rs
@@ -64,16 +64,17 @@ impl GoogleAuthTokenGenerator {
         pick: impl FnOnce(&CachedToken) -> R,
     ) -> crate::error::Result<R> {
         let now = Timestamp::now();
+        // Give a bit more time for the network call than the token strictly has left;
+        // both the read-only fast path and the write-lock recheck below must use this
+        // same threshold, or a token can sit inside the margin forever, with every
+        // caller taking the write lock and getting the stale token back without ever
+        // triggering the refresh the margin exists to trigger.
+        let refresh_after = now.add(SignedDuration::from_secs(15));
 
         {
             let read_state = self.cached_token.read().await;
-            // Give a bit more time for network call
             if let Some(cached) = read_state.as_ref() {
-                if cached
-                    .token
-                    .expiry
-                    .gt(&now.add(SignedDuration::from_secs(15)))
-                {
+                if cached.token.expiry.gt(&refresh_after) {
                     return Ok(pick(cached));
                 }
             }
@@ -81,7 +82,7 @@ impl GoogleAuthTokenGenerator {
 
         let mut write_token = self.cached_token.write().await;
         match write_token.as_ref() {
-            Some(updated_cached) if updated_cached.token.expiry.gt(&now) => {
+            Some(updated_cached) if updated_cached.token.expiry.gt(&refresh_after) => {
                 Ok(pick(updated_cached))
             }
             _ => {
@@ -143,5 +144,42 @@ mod tests {
         assert_eq!(first, second);
         assert!(first.is_sensitive());
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    struct FixedExpirySource {
+        calls: Arc<AtomicUsize>,
+        expires_in: SignedDuration,
+    }
+
+    #[async_trait]
+    impl Source for FixedExpirySource {
+        async fn token(&self) -> crate::error::Result<Token> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Token {
+                token_type: "Bearer".to_string(),
+                token: SecretValue::from("margin-token"),
+                expiry: Timestamp::now() + self.expires_in,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn token_inside_refresh_margin_is_refreshed() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let source = FixedExpirySource {
+            calls: calls.clone(),
+            expires_in: SignedDuration::from_secs(10),
+        };
+        let generator = GoogleAuthTokenGenerator::new(
+            TokenSourceType::ExternalSource(Box::new(source)),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        generator.authorization_header().await.unwrap();
+        generator.authorization_header().await.unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/gcloud-sdk/src/token_source/auth_token_generator.rs
+++ b/gcloud-sdk/src/token_source/auth_token_generator.rs
@@ -58,8 +58,7 @@ impl GoogleAuthTokenGenerator {
     }
 
     /// Runs the double-checked refresh and applies `pick` to the resulting cached
-    /// token by reference, so a cache hit clones only what the caller asks for
-    /// instead of the whole `CachedToken`.
+    /// token by reference, so a cache hit clones only what the caller asks for.
     async fn with_cached<R>(
         &self,
         pick: impl FnOnce(&CachedToken) -> R,

--- a/gcloud-sdk/src/token_source/auth_token_generator.rs
+++ b/gcloud-sdk/src/token_source/auth_token_generator.rs
@@ -7,7 +7,6 @@ use tracing::*;
 
 /// A token together with its pre-validated `authorization` header value, so that
 /// serving a cache hit never re-parses or re-allocates the header.
-#[derive(Clone)]
 struct CachedToken {
     token: Token,
     authorization: HeaderValue,
@@ -48,54 +47,54 @@ impl GoogleAuthTokenGenerator {
     }
 
     pub async fn create_token(&self) -> crate::error::Result<Token> {
-        self.refreshed().await.map(|cached| cached.token)
+        self.with_cached(|cached| cached.token.clone()).await
     }
 
     /// The `authorization` header value for the current token, already validated
     /// and marked sensitive; cloning it is a `Bytes` refcount bump, not an allocation.
     pub async fn authorization_header(&self) -> crate::error::Result<HeaderValue> {
-        self.refreshed().await.map(|cached| cached.authorization)
+        self.with_cached(|cached| cached.authorization.clone())
+            .await
     }
 
-    async fn refreshed(&self) -> crate::error::Result<CachedToken> {
-        let existing_token: Option<CachedToken> = {
-            let read_state = self.cached_token.read().await;
-            read_state.clone()
-        };
-
+    /// Runs the double-checked refresh and applies `pick` to the resulting cached
+    /// token by reference, so a cache hit clones only what the caller asks for
+    /// instead of the whole `CachedToken`.
+    async fn with_cached<R>(
+        &self,
+        pick: impl FnOnce(&CachedToken) -> R,
+    ) -> crate::error::Result<R> {
         let now = Timestamp::now();
 
-        match existing_token {
+        {
+            let read_state = self.cached_token.read().await;
             // Give a bit more time for network call
-            Some(cached)
+            if let Some(cached) = read_state.as_ref() {
                 if cached
                     .token
                     .expiry
-                    .gt(&now.add(SignedDuration::from_secs(15))) =>
-            {
-                Ok(cached)
+                    .gt(&now.add(SignedDuration::from_secs(15)))
+                {
+                    return Ok(pick(cached));
+                }
+            }
+        }
+
+        let mut write_token = self.cached_token.write().await;
+        match write_token.as_ref() {
+            Some(updated_cached) if updated_cached.token.expiry.gt(&now) => {
+                Ok(pick(updated_cached))
             }
             _ => {
-                let new_cached = {
-                    let mut write_token = self.cached_token.write().await;
-
-                    match write_token.as_ref() {
-                        Some(updated_cached) if updated_cached.token.expiry.gt(&now) => {
-                            updated_cached.clone()
-                        }
-                        _ => {
-                            let new_token = self.token_source.token().await?;
-                            debug!(
-                                "Created a new Google OAuth token. Type: {}. Expiring: {}.",
-                                new_token.token_type, new_token.expiry,
-                            );
-                            let new_cached = CachedToken::from_token(new_token)?;
-                            *write_token = Some(new_cached.clone());
-                            new_cached
-                        }
-                    }
-                };
-                Ok(new_cached)
+                let new_token = self.token_source.token().await?;
+                debug!(
+                    "Created a new Google OAuth token. Type: {}. Expiring: {}.",
+                    new_token.token_type, new_token.expiry,
+                );
+                let new_cached = CachedToken::from_token(new_token)?;
+                let result = pick(&new_cached);
+                *write_token = Some(new_cached);
+                Ok(result)
             }
         }
     }

--- a/gcloud-sdk/src/token_source/credentials.rs
+++ b/gcloud-sdk/src/token_source/credentials.rs
@@ -445,7 +445,7 @@ mod external_account {
                 } else {
                     let status = iam_generate_token_response.status();
                     let err_body = iam_generate_token_response.text().await?;
-                    let err_text = format!("Unable to receive subject using external impersonation url: {}. HTTP: {} {}", &external_account.token_url, status, err_body);
+                    let err_text = format!("Unable to receive subject using external impersonation url: {}. HTTP: {} {}", external_account.token_url, status, err_body);
                     Err(crate::error::ErrorKind::ExternalCredsSourceError(err_text).into())
                 }
             } else {
@@ -456,7 +456,7 @@ mod external_account {
             let err_body = sts_http_response.text().await?;
             let err_text = format!(
                 "Unable to receive subject using external url: {}. HTTP: {} {}",
-                &external_account.token_url, status, err_body
+                external_account.token_url, status, err_body
             );
             Err(crate::error::ErrorKind::ExternalCredsSourceError(err_text).into())
         }
@@ -600,7 +600,7 @@ mod impersonate_account {
             let err_body = iam_generate_token_response.text().await?;
             let err_text = format!(
                 "Unable to receive subject using impersonation url: {}. HTTP: {} {}",
-                &impersonate_account.service_account_impersonation_url, status, err_body
+                impersonate_account.service_account_impersonation_url, status, err_body
             );
             Err(crate::error::ErrorKind::ExternalCredsSourceError(err_text).into())
         }

--- a/gcloud-sdk/src/token_source/ext_creds_source/mod.rs
+++ b/gcloud-sdk/src/token_source/ext_creds_source/mod.rs
@@ -131,7 +131,7 @@ pub async fn subject_token_url(
         let err_body = response.text().await?;
         let err_text = format!(
             "Unable to receive subject using external credential url: {}. HTTP: {} {}",
-            &url_creds.url, status, err_body
+            url_creds.url, status, err_body
         );
         Err(crate::error::ErrorKind::ExternalCredsSourceError(err_text).into())
     }

--- a/gcloud-sdk/src/token_source/gce/gce_metadata_client.rs
+++ b/gcloud-sdk/src/token_source/gce/gce_metadata_client.rs
@@ -81,7 +81,7 @@ impl GceMetadataClient {
                 if !resolved {
                     // Last resort, try to use IP address with HTTP call
                     match client
-                        .get(&format!("http://{}/", GCE_METADATA_IP))
+                        .get(format!("http://{}/", GCE_METADATA_IP))
                         .send()
                         .await
                     {


### PR DESCRIPTION
The auth middleware cloned three Strings and a HeaderMap and re-parsed them into HeaderValues on every call, rebuilt the bearer token header String per request, and held the inner service in an Option only to swap it. Fixed headers are now validated once into a shared Arc<HeaderMap>, the token generator caches a sensitive-marked authorization HeaderValue next to the token so a cache hit is a refcount bump, and the inner service is a plain T using tower's clone-and-replace idiom. Along the way two pre-existing bugs are fixed with tests: repeated values of an additional header were truncated to one, and the 15s early-refresh margin never triggered a refresh because the write-lock recheck used a bare now.

Breaking: the layer and service setters and new(), and GoogleApiClient::amend_user_agent / amend_x_goog_api_client, now return Result since header values are validated at set time; the layer's fields are private; ErrorKind is #[non_exhaustive] instead of carrying a hidden variant. Amending the user agent after an additional user-agent header was set now appends to it instead of being silently overridden.